### PR TITLE
Changes made during the plugin critique video

### DIFF
--- a/src/obsidian/plugin/main.ts
+++ b/src/obsidian/plugin/main.ts
@@ -257,7 +257,7 @@ export default class ObsidianTimelinePlugin extends obsidian.Plugin {
 				.showAtMouseEvent(event);
 		});
 
-		this.app.workspace.on("editor-menu", (menu, editor, info) => {
+		this.registerEvent(this.app.workspace.on("editor-menu", (menu, editor, info) => {
 			const pos = editor.getCursor();
 			const line = editor.getLine(pos.line);
 
@@ -274,7 +274,7 @@ export default class ObsidianTimelinePlugin extends obsidian.Plugin {
 						});
 					});
 			});
-		});
+		}));
 
 		this.registerEvent(
 			this.app.workspace.on(

--- a/src/obsidian/plugin/main.ts
+++ b/src/obsidian/plugin/main.ts
@@ -323,7 +323,4 @@ export default class ObsidianTimelinePlugin extends obsidian.Plugin {
 		}
 	}
 
-	onunload(): void {
-		this.app.workspace.detachLeavesOfType(OBSIDIAN_LEAF_VIEW_TYPE);
-	}
 }

--- a/src/obsidian/plugin/timeline-item-view.ts
+++ b/src/obsidian/plugin/timeline-item-view.ts
@@ -35,7 +35,7 @@ export class TimelineItemView extends obsidian.ItemView {
 		private noteProperties: ObsidianNotePropertyRepository,
 	) {
 		super(leaf);
-		this.navigation = false;
+		this.navigation = true;
 
 		this.scope = new obsidian.Scope(this.app.scope);
 		this.scope.register(["Shift"], " ", () => {

--- a/src/obsidian/plugin/timeline-item-view.ts
+++ b/src/obsidian/plugin/timeline-item-view.ts
@@ -222,7 +222,7 @@ export class TimelineItemView extends obsidian.ItemView {
 	}
 
 	protected async onOpen(): Promise<void> {
-		const content = this.containerEl.children[1];
+		const content = this.contentEl;
 
 		content.createEl("progress");
 

--- a/src/obsidian/plugin/timeline-item-view.ts
+++ b/src/obsidian/plugin/timeline-item-view.ts
@@ -123,37 +123,18 @@ export class TimelineItemView extends obsidian.ItemView {
 		menu: obsidian.Menu,
 		source: "more-options" | "tab-header" | string,
 	): void {
-		if (this.$mode === EditMode.Edit) {
-			menu.addItem(item => {
-				item.setIcon("book-open")
-					.setSection("pane")
-					.setTitle("View-only timeline")
-					.onClick(() => {
-						this.mode.set(EditMode.View);
-					});
-			});
-		} else if (this.$mode === EditMode.View) {
-			menu.addItem(item => {
-				item.setIcon("edit-3")
-					.setSection("pane")
-					.setTitle("Edit timeline")
-					.onClick(() => {
-						this.mode.set(EditMode.Edit);
-					});
-			});
-		}
+		super.onPaneMenu(menu, source);
 		menu.addItem(item => {
-			item.setIcon("link")
-				.setSection("view.linked")
-				.setTitle("Open linked markdown tab")
+			item.setIcon("book-open")
+				.setChecked(this.$mode === EditMode.View)
+				.setSection("pane")
+				.setTitle("View-only timeline")
 				.onClick(() => {
-					this.workspace.getLeaf("split", "horizontal").setViewState({
-						type: "empty",
-						group: this.leaf,
-					});
+					this.mode.set(this.$mode === EditMode.View 
+						? EditMode.Edit 
+						: EditMode.View);
 				});
 		});
-		return super.onPaneMenu(menu, source);
 	}
 
 	private openNoteInLinkedLeaf(note: Note): boolean {

--- a/src/timeline/Timeline.svelte
+++ b/src/timeline/Timeline.svelte
@@ -257,6 +257,7 @@
 		position: absolute;
 		top: var(--ruler-height);
 		margin-top: var(--size-4-2);
+		margin-right: var(--size-4-2);
 		right: calc(100% - var(--stage-client-width));
 	}
 	/*! Icon sizing */

--- a/src/timeline/controls/TimelineNavigationControls.svelte
+++ b/src/timeline/controls/TimelineNavigationControls.svelte
@@ -30,6 +30,7 @@
 	<li class="control-item">
 		<ActionButton
 			aria-label="Zoom In"
+			data-tooltip-position="left"
 			on:action={triggerZoomIn}
 			class="clickable-icon"
 		>
@@ -39,6 +40,7 @@
 	<li class="control-item">
 		<ActionButton
 			aria-label="Zoom Out"
+			data-tooltip-position="left"
 			on:action={triggerZoomOut}
 			class="clickable-icon"
 		>
@@ -48,6 +50,7 @@
 	<li class="control-item">
 		<ActionButton
 			aria-label="Zoom to Fit"
+			data-tooltip-position="left"
 			on:action={triggerZoomToFit}
 			class="clickable-icon"
 		>
@@ -57,6 +60,7 @@
 	<li class="control-item">
 		<ActionButton
 			aria-label="Scroll to Zero"
+			data-tooltip-position="left"
 			on:action={triggerScrollToZero}
 			class="clickable-icon"
 		>
@@ -66,6 +70,7 @@
 	<li class="control-item">
 		<ActionButton
 			aria-label="Scroll to First"
+			data-tooltip-position="left"
 			on:action={triggerScrollToFirst}
 			class="clickable-icon"
 		>

--- a/src/timeline/controls/settings/TimelineSettings.svelte
+++ b/src/timeline/controls/settings/TimelineSettings.svelte
@@ -35,6 +35,7 @@
 			id="toggle-button"
 			class="open-button clickable-icon"
 			aria-label="Open"
+			data-tooltip-position="left"
 			on:action={() => (isOpen = true)}
 		>
 			<LucideIcon id="settings" />
@@ -44,6 +45,7 @@
 			id="toggle-button"
 			class="close-button clickable-icon"
 			aria-label="Close"
+			data-tooltip-position="left"
 			on:action={() => (isOpen = false)}
 		>
 			<LucideIcon id="x" />

--- a/src/timeline/group/GroupColorInput.svelte
+++ b/src/timeline/group/GroupColorInput.svelte
@@ -38,6 +38,7 @@
 <input
 	type="color"
 	aria-label={"Click to change color\nDrag to reorder groups"}
+	data-tooltip-position="left"
 	bind:value={color}
 	on:mousedown={onmousedown}
 	{...$$restProps}

--- a/src/timeline/group/GroupListItem.svelte
+++ b/src/timeline/group/GroupListItem.svelte
@@ -67,6 +67,7 @@
 	<ActionButton
 		class="clickable-icon"
 		aria-label="Delete group"
+		data-tooltip-position="left"
 		on:action={onRemove}
 	>
 		<svg

--- a/src/timeline/layout/stage/CanvasStage.svelte
+++ b/src/timeline/layout/stage/CanvasStage.svelte
@@ -830,9 +830,6 @@
 			pointStyle?: TimelineItemElementStyle,
 		) {
 			if (canvas == null) return;
-			if (canvas.width != viewport.width) canvas.width = viewport.width;
-			if (canvas.height != viewport.height)
-				canvas.height = viewport.height;
 			const renderContext = canvas.getContext("2d");
 			if (renderContext == null) return;
 
@@ -989,6 +986,15 @@
 							element.style = selectedStyle;
 						}
 					}
+				}
+
+				const ratio = activeWindow.devicePixelRatio || 1;
+				if (canvas.width != viewport.width * ratio || canvas.height != viewport.height * ratio) {
+					canvas.width = viewport.width * ratio;
+					canvas.height = viewport.height * ratio;
+					canvas.style.width = viewport.width + 'px';
+					canvas.style.height = viewport.height + 'px';
+					renderContext.scale(ratio, ratio);
 				}
 
 				renderLayout(renderContext, viewport, elements, dragPreview);

--- a/src/timeline/sorting/TimelineNoteSorterProperty.ts
+++ b/src/timeline/sorting/TimelineNoteSorterProperty.ts
@@ -48,6 +48,10 @@ export class NotePropertyValueSelector implements NumericNoteValueSelector {
 		const value = note.properties()[this.property.name()];
 		if (typeof value === "number") return value;
 		if (typeof value === "string") {
+			const datetime = window.moment(value);
+			if (datetime.isValid()) {
+				return datetime.valueOf();
+			}
 			const parsed = parseFloat(value);
 			if (!isNaN(parsed)) return parsed;
 			return 0;


### PR DESCRIPTION
Here is a full list of changes made in the Obsidian October plugin critique video. Some of these changes are opinionated so feel free to only include the bug fixes.

- [x] [Fixes blurry canvas element](<https://youtu.be/sbncjuJDAyU?t=181>)
- [x] [Timeline navigation button alignment](<https://youtu.be/sbncjuJDAyU?t=378>)
- [x] [Tooltip positioning](<https://youtu.be/sbncjuJDAyU?t=434>)
- [x] [Add missing registerEvent](<https://youtu.be/sbncjuJDAyU?t=950>)
- [x] [Set navigation=true](<https://youtu.be/sbncjuJDAyU?t=1137>)
- [x] [Changing the Edit/Read-only menu item into a checked menu item](<https://youtu.be/sbncjuJDAyU?t=1570>)
- [x] [Fix datetime property conversion](<https://youtu.be/sbncjuJDAyU?t=2039>)