### PR TITLE
use svelte 5 syntax for group management

### DIFF
--- a/src/svelte/reactive.ts
+++ b/src/svelte/reactive.ts
@@ -1,0 +1,2 @@
+/** indicates that the returned value is reactive */
+export type Reactive<T> = () => T;

--- a/src/timeline/Timeline.svelte
+++ b/src/timeline/Timeline.svelte
@@ -10,15 +10,8 @@
 	import TimelineNavigationControls from "./controls/TimelineNavigationControls.svelte";
 	import TimelineSettings from "./controls/settings/TimelineSettings.svelte";
 	import type { RulerValueDisplay } from "src/timeline/Timeline";
-	import type { TimelineGroups } from "src/timeline/group/groups";
-	import TimelineGroupsList from "src/timeline/group/TimelineGroupsList.svelte";
-	import {
-		type ComponentProps,
-		mount,
-		type Snippet,
-		unmount,
-		untrack,
-	} from "svelte";
+	import { type Groups as TimelineGroups } from "src/timeline/group/TimelineGroupsList.svelte";
+	import { mount, type Snippet, unmount, untrack } from "svelte";
 	import TimelineGroupsSettingsSection from "src/timeline/group/TimelineGroupsSettingsSection.svelte";
 	import { ObservableCollapsable } from "src/view/collapsable";
 	import LucideIcon from "src/obsidian/view/LucideIcon.svelte";
@@ -35,7 +28,6 @@
 	interface Props {
 		namespacedWritable: NamespacedWritableFactory<TimelineViewModel>;
 		groups: TimelineGroups;
-		groupEvents: Omit<ComponentProps<typeof TimelineGroupsList>, "groups">;
 		display: RulerValueDisplay;
 		controlBindings: {};
 
@@ -80,7 +72,6 @@
 	const {
 		namespacedWritable,
 		groups,
-		groupEvents,
 		display,
 
 		items: inputItems,
@@ -267,12 +258,6 @@
 		.namespace("settings")
 		.namespace("groups")
 		.make("collapsed", true);
-	const groupsSectionCollapable = new ObservableCollapsable(
-		$groupsSectionCollapsed,
-	);
-	groupsSectionCollapable.onChange = () => {
-		$groupsSectionCollapsed = groupsSectionCollapable.isCollapsed();
-	};
 
 	function openHelpDialog() {
 		openDialog((modal) => {
@@ -343,10 +328,9 @@
 		<TimelineSettings collapsable={settingsCollapable}>
 			{@render additionalSettings()}
 			<TimelineGroupsSettingsSection
-				collapsable={groupsSectionCollapable}
+				bind:collapsed={$groupsSectionCollapsed}
 				{groups}
 				{pendingGroupUpdates}
-				{...groupEvents}
 			/>
 		</TimelineSettings>
 		<div class="control-group">

--- a/src/timeline/group/GroupColorInput.svelte
+++ b/src/timeline/group/GroupColorInput.svelte
@@ -1,42 +1,11 @@
 <script lang="ts">
-	import { run } from "svelte/legacy";
-
-	import type * as colors from "src/color";
-	import type * as svelteElements from "svelte/elements";
-
 	interface Props {
 		onmousedown?(event: MouseEvent & { currentTarget: HTMLElement }): void;
-		onchanged?(color: string): void;
-		colorable: colors.ColoredColorable;
-		[key: string]: any;
+		/** @bindable */
+		color: string;
 	}
 
-	let {
-		onmousedown = undefined,
-		onchanged = undefined,
-		colorable,
-		...rest
-	}: Props = $props();
-
-	let color = $state(colorable.color());
-	function onNewColorable(colorable: colors.ColoredColorable) {
-		color = colorable.color();
-	}
-	run(() => {
-		onNewColorable(colorable);
-	});
-
-	function onColorInput(color: string) {
-		if (color !== colorable.color()) {
-			colorable.recolor(color);
-			color = colorable.color();
-			if (onchanged != null) onchanged(color);
-		}
-	}
-
-	run(() => {
-		onColorInput(color);
-	});
+	let { onmousedown = undefined, color = $bindable() }: Props = $props();
 </script>
 
 <input
@@ -45,7 +14,6 @@
 	data-tooltip-position="left"
 	bind:value={color}
 	{onmousedown}
-	{...rest}
 />
 
 <style>

--- a/src/timeline/group/GroupListItem.svelte
+++ b/src/timeline/group/GroupListItem.svelte
@@ -1,16 +1,37 @@
+<script lang="ts" module>
+	export class Group {
+		#query = $state("");
+		query() {
+			return this.#query;
+		}
+		filterByQuery(query: string) {
+			this.#query = query;
+		}
+
+		#color = $state("");
+		color() {
+			return this.#color;
+		}
+		recolor(color: string) {
+			this.#color = color;
+		}
+
+		constructor(query: string, color: string) {
+			this.#query = query;
+			this.#color = color;
+		}
+	}
+</script>
+
 <script lang="ts">
-	import type { TimelineGroup } from "src/timeline/group/group";
 	import GroupColorInput from "src/timeline/group/GroupColorInput.svelte";
 	import GroupQueryInput from "src/timeline/group/GroupQueryInput.svelte";
 	import ActionButton from "src/view/inputs/ActionButton.svelte";
-	import { onDestroy } from "svelte";
 
 	interface Props {
-		group: TimelineGroup;
+		group: Group;
 		class?: string;
 		style?: string;
-		onRecolored?(group: TimelineGroup): void;
-		onRequeried?(group: TimelineGroup): void;
 		onRemove?: () => void;
 		onPressDragHandle?(event: {
 			readonly currentTarget: HTMLElement;
@@ -25,8 +46,6 @@
 		group,
 		class: className = undefined,
 		style = undefined,
-		onRecolored = undefined,
-		onRequeried = undefined,
 		onRemove = undefined,
 		onPressDragHandle = undefined,
 	}: Props = $props();
@@ -38,12 +57,13 @@
 	) {
 		if (onPressDragHandle && element) {
 			const currentTarget = element;
+			const elementBounds = element.getBoundingClientRect();
 			onPressDragHandle({
 				get currentTarget() {
 					return currentTarget;
 				},
-				offsetX: event.offsetX + event.currentTarget.offsetLeft,
-				offsetY: event.offsetY + event.currentTarget.offsetTop,
+				offsetX: event.clientX - elementBounds.x,
+				offsetY: event.clientY - elementBounds.y,
 				clientX: event.clientX,
 				clientY: event.clientY,
 			});
@@ -57,12 +77,10 @@
 	{style}
 >
 	<GroupQueryInput
-		queriable={group}
-		onchanged={onRequeried ? () => onRequeried(group) : undefined}
+		bind:query={() => group.query(), (query) => group.filterByQuery(query)}
 	/>
 	<GroupColorInput
-		colorable={group}
-		onchanged={onRecolored ? () => onRecolored(group) : undefined}
+		bind:color={() => group.color(), (color) => group.recolor(color)}
 		onmousedown={onPressDragHandle ? onDragHandeMouseDown : undefined}
 	/>
 	<ActionButton

--- a/src/timeline/group/GroupQueryInput.svelte
+++ b/src/timeline/group/GroupQueryInput.svelte
@@ -1,35 +1,10 @@
 <script lang="ts">
-	import { run } from 'svelte/legacy';
-
-	import type { QueryFilterReaderWriter } from "src/timeline/filter/query";
-
 	interface Props {
-		queriable: QueryFilterReaderWriter;
-		onchanged?: undefined | ((query: string) => void);
+		/** @bindable */
+		query: string;
 	}
 
-	let { queriable, onchanged = undefined }: Props = $props();
-
-	let query = $state(queriable.query());
-	function onNewQueriable(queriable: QueryFilterReaderWriter) {
-		query = queriable.query();
-	}
-	run(() => {
-		onNewQueriable(queriable);
-	});
-
-	function onQueryInput(query: string) {
-		if (query !== queriable.query()) {
-			queriable.filterByQuery(query);
-			query = queriable.query();
-			if (onchanged != null) {
-				onchanged(query);
-			}
-		}
-	}
-	run(() => {
-		onQueryInput(query);
-	});
+	let { query = $bindable() }: Props = $props();
 </script>
 
 <input

--- a/src/timeline/group/TimelineGroupsSettingsSection.svelte
+++ b/src/timeline/group/TimelineGroupsSettingsSection.svelte
@@ -2,55 +2,24 @@
 	import { run } from "svelte/legacy";
 
 	import LucideIcon from "src/obsidian/view/LucideIcon.svelte";
-	import type { TimelineGroups } from "src/timeline/group/groups";
-	import TimelineGroupsList from "src/timeline/group/TimelineGroupsList.svelte";
+	import TimelineGroupsList, {
+		type Groups as TimelineGroups,
+	} from "src/timeline/group/TimelineGroupsList.svelte";
 	import type { Collapsable } from "src/view/collapsable";
 	import CollapsableSection from "src/view/CollapsableSection.svelte";
-	import type { ComponentProps } from "svelte";
-
-	type TimelineGroupsListProps = ComponentProps<typeof TimelineGroupsList>;
 
 	interface Props {
-		collapsable: Collapsable;
+		/** @bindable */
+		collapsed: boolean;
 		pendingGroupUpdates: number;
 		groups: TimelineGroups;
-		onGroupAppended?: TimelineGroupsListProps["onGroupAppended"];
-		onGroupsReordered?: TimelineGroupsListProps["onGroupsReordered"];
-		onGroupRemoved?: TimelineGroupsListProps["onGroupRemoved"];
-		onGroupColored?: TimelineGroupsListProps["onGroupColored"];
-		onGroupQueried?: TimelineGroupsListProps["onGroupQueried"];
 	}
 
 	let {
-		collapsable,
+		collapsed = $bindable(),
 		pendingGroupUpdates,
 		groups,
-		onGroupAppended = undefined,
-		onGroupsReordered = undefined,
-		onGroupRemoved = undefined,
-		onGroupColored = undefined,
-		onGroupQueried = undefined,
 	}: Props = $props();
-
-	let collapsed = $state(collapsable.isCollapsed());
-	function onCollapsableChanged(collapsable: Props["collapsable"]) {
-		collapsed = collapsable.isCollapsed();
-	}
-	function onCollapsedChanged(collapsed: boolean) {
-		if (collapsed) {
-			collapsable.collapse();
-		} else {
-			collapsable.expand();
-		}
-		collapsed = collapsable.isCollapsed();
-	}
-
-	run(() => {
-		onCollapsableChanged(collapsable);
-	});
-	run(() => {
-		onCollapsedChanged(collapsed);
-	});
 </script>
 
 <CollapsableSection
@@ -68,14 +37,7 @@
 			{pendingGroupUpdates.toLocaleString()} pending
 		</span>
 	{/if}
-	<TimelineGroupsList
-		{groups}
-		{onGroupAppended}
-		{onGroupsReordered}
-		{onGroupRemoved}
-		{onGroupColored}
-		{onGroupQueried}
-	/>
+	<TimelineGroupsList {groups} />
 </CollapsableSection>
 
 <style>

--- a/src/utils/tasks.ts
+++ b/src/utils/tasks.ts
@@ -1,0 +1,54 @@
+export class TaskQueue {
+	static new() {
+		let end = 0;
+		return new TaskQueue(
+			() => {
+				end = performance.now() + 16;
+			},
+			() => end >= performance.now(),
+		);
+	}
+	constructor(private readonly onBatchStart: () => void, private readonly continueBatch: () => boolean) {}
+
+	private tasks: (() => Promise<void> | void)[] = [];
+	#running = false;
+	enqueue(task: () => Promise<void> | void) {
+		if (this.cancelled) return;
+		this.tasks.push(task);
+		if (!this.#running) {
+			this.#running = true;
+			this.#process();
+		}
+	}
+
+	#progressCallbacks = new Set<(length: number) => void>();
+	onProgress(cb: (length: number) => void) {
+		cb(this.tasks.length);
+		this.#progressCallbacks.add(cb);
+	}
+
+	private cancelled = false;
+	cancel() {
+		this.cancelled = true;
+	}
+
+	async #process(previousBatch: Promise<unknown> = Promise.resolve()) {
+		if (this.cancelled) return;
+
+		this.onBatchStart();
+		await previousBatch;
+
+		const batch: Array<Promise<void> | void> = [];
+		let task = this.tasks.shift();
+		while (task && this.continueBatch()) {
+			batch.push(task());
+			task = this.tasks.shift();
+		}
+		this.#progressCallbacks.forEach(cb => cb(this.tasks.length));
+		if (batch.length > 0) {
+			setTimeout(() => this.#process(Promise.all(batch)), 0);
+		} else {
+			this.#running = false;
+		}
+	}
+}

--- a/src/view/Portal.svelte
+++ b/src/view/Portal.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import type { Snippet } from "svelte";
+
+	const {
+		open = false,
+		top,
+		left,
+		children,
+		class: className,
+	}: {
+		open?: boolean;
+		top?: string;
+		left?: string;
+		class?: string;
+		children?: Snippet;
+	} = $props();
+
+	let dialog = $state<HTMLDialogElement | null>(null);
+	$effect(() => {
+		if (
+			dialog !== null &&
+			dialog.parentElement !== dialog.ownerDocument?.body
+		) {
+			dialog.ownerDocument?.body?.appendChild(dialog);
+		}
+	});
+</script>
+
+<dialog {open} style:top style:left bind:this={dialog} class={className}>
+	{@render children?.()}
+</dialog>
+
+<style>
+	dialog {
+		padding: 0;
+		border: none;
+		margin: unset;
+		background: none;
+		z-index: 9999;
+		position: fixed;
+	}
+</style>


### PR DESCRIPTION
Fixes #46
introduces some unnecessary processing through the `$effect` because we lost the ability to see what event triggered the change to the group list.  May fix later.